### PR TITLE
changed create route so that it will save username instead of email

### DIFF
--- a/controllers/api/user-routes.js
+++ b/controllers/api/user-routes.js
@@ -69,11 +69,11 @@ router.post('/', (req, res) => {
     occupation: req.body.occupation,
     about: req.body.about
   })
-    //save user id and email to a session
+    //save user id and username to a session
     .then(dbUserData => {
       req.session.save(() => {
         req.session.user_id = dbUserData.id;
-        req.session.email = dbUserData.email;
+        req.session.username = dbUserData.username;
         req.session.loggedIn = true;
     
         res.json(dbUserData);


### PR DESCRIPTION
ran into a problem: after creating a new user, it would not allow me to login later as that user. just had to change the createUser route to save username to the session instead of email. 